### PR TITLE
refactor: unify counts parsing

### DIFF
--- a/scripts/add_random_mace_relax.py
+++ b/scripts/add_random_mace_relax.py
@@ -8,15 +8,7 @@ from phaseedge.jobs.random_config import RandomConfigSpec
 from phaseedge.science.prototypes import make_prototype
 from phaseedge.science.random_configs import validate_counts_for_sublattice
 from phaseedge.utils.keys import compute_set_id_counts
-
-
-def _parse_counts_arg(s: str) -> dict[str, int]:
-    """Parse --counts 'Co:76,Fe:32' -> {'Co': 76, 'Fe': 32}."""
-    out: dict[str, int] = {}
-    for kv in s.split(","):
-        k, v = kv.split(":")
-        out[k.strip()] = int(v)
-    return out
+from phaseedge.cli.common import parse_counts_arg
 
 
 def main() -> None:
@@ -49,7 +41,7 @@ def main() -> None:
     p.add_argument("--category", default="gpu")
 
     args = p.parse_args()
-    counts = _parse_counts_arg(args.counts)
+    counts = parse_counts_arg(args.counts)
 
     # Build the conventional prototype for validation only
     conv = make_prototype(args.prototype, a=args.a)

--- a/src/phaseedge/cli/common.py
+++ b/src/phaseedge/cli/common.py
@@ -1,0 +1,36 @@
+"""Shared CLI helpers."""
+from __future__ import annotations
+
+from typing import Dict
+
+__all__ = ["parse_counts_arg"]
+
+
+def parse_counts_arg(s: str) -> Dict[str, int]:
+    """Parse 'Fe:54,Mn:54' -> {'Fe': 54, 'Mn': 54} (whitespace-tolerant).
+
+    The argument is a comma-separated list of ``element:count`` pairs. Whitespace
+    around tokens is ignored. Duplicate elements, missing counts, and negative
+    values raise ``ValueError``. At least one pair is required.
+    """
+    out: Dict[str, int] = {}
+    for kv in s.split(","):
+        kv = kv.strip()
+        if not kv:
+            continue
+        if ":" not in kv:
+            raise ValueError(f"Bad counts token '{kv}' (expected 'El:INT').")
+        k, v = kv.split(":", 1)
+        k = k.strip()
+        v = v.strip()
+        if not k:
+            raise ValueError(f"Empty element in counts token '{kv}'.")
+        if k in out:
+            raise ValueError(f"Duplicate element '{k}' in counts.")
+        iv = int(v)
+        if iv < 0:
+            raise ValueError(f"Negative count for '{k}': {iv}")
+        out[k] = iv
+    if not out:
+        raise ValueError("Empty counts string.")
+    return out

--- a/src/phaseedge/cli/ensure_ce.py
+++ b/src/phaseedge/cli/ensure_ce.py
@@ -13,27 +13,7 @@ from fireworks import LaunchPad
 from phaseedge.science.prototypes import make_prototype
 from phaseedge.science.random_configs import validate_counts_for_sublattice
 from phaseedge.utils.keys import compute_ce_key_mixture
-
-
-def _parse_counts_arg(s: str) -> dict[str, int]:
-    out: dict[str, int] = {}
-    for kv in s.split(","):
-        kv = kv.strip()
-        if not kv:
-            continue
-        if ":" not in kv:
-            raise ValueError(f"Bad counts token '{kv}' (expected 'El:INT').")
-        k, v = kv.split(":", 1)
-        k = k.strip()
-        v = v.strip()
-        if not k:
-            raise ValueError(f"Empty element in counts token '{kv}'.")
-        if k in out:
-            raise ValueError(f"Duplicate element '{k}' in --counts.")
-        out[k] = int(v)
-    if not out:
-        raise ValueError("Empty --counts.")
-    return out
+from phaseedge.cli.common import parse_counts_arg
 
 
 def _parse_cutoffs_arg(s: str) -> dict[int, float]:
@@ -66,7 +46,7 @@ def _parse_mix_item(s: str) -> dict[str, Any]:
         k = k.strip().lower()
         v = v.strip()
         if k == "counts":
-            item["counts"] = _parse_counts_arg(v)
+            item["counts"] = parse_counts_arg(v)
         elif k == "k":
             item["K"] = int(v)
         elif k == "seed":
@@ -136,7 +116,7 @@ def main() -> None:
     else:
         if args.counts is None or args.seed is None or args.K is None:
             raise SystemExit("When --mix is not used, you must provide --counts, --seed, and --K.")
-        mixture = [{"counts": _parse_counts_arg(args.counts), "K": int(args.K), "seed": int(args.seed)}]
+        mixture = [{"counts": parse_counts_arg(args.counts), "K": int(args.K), "seed": int(args.seed)}]
         default_seed = int(args.seed)
 
     # Optional early validation

--- a/src/phaseedge/cli/ensure_wang_landau.py
+++ b/src/phaseedge/cli/ensure_wang_landau.py
@@ -8,31 +8,7 @@ from jobflow.managers.fireworks import flow_to_workflow
 
 from phaseedge.jobs.check_or_schedule_wl import WLEnsureSpec, check_or_schedule_wl
 from phaseedge.utils.keys import compute_wl_key
-
-
-def _parse_counts_arg(s: str) -> dict[str, int]:
-    """Parse 'Fe:54,Mn:54' -> {'Fe': 54, 'Mn': 54} (whitespace-tolerant)."""
-    out: dict[str, int] = {}
-    for kv in s.split(","):
-        kv = kv.strip()
-        if not kv:
-            continue
-        if ":" not in kv:
-            raise ValueError(f"Bad counts token '{kv}' (expected 'El:INT').")
-        k, v = kv.split(":", 1)
-        k = k.strip()
-        v = v.strip()
-        if not k:
-            raise ValueError(f"Empty element in counts token '{kv}'.")
-        if k in out:
-            raise ValueError(f"Duplicate element '{k}' in --composition-counts.")
-        iv = int(v)
-        if iv < 0:
-            raise ValueError(f"Negative count for '{k}': {iv}")
-        out[k] = iv
-    if not out:
-        raise ValueError("Empty --composition-counts.")
-    return out
+from phaseedge.cli.common import parse_counts_arg
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -64,7 +40,7 @@ def main() -> int:
     p = build_parser()
     args = p.parse_args()
 
-    composition_counts: Dict[str, int] = _parse_counts_arg(args.composition_counts)
+    composition_counts: Dict[str, int] = parse_counts_arg(args.composition_counts)
 
     # Compute the wl_key up-front (public contract only) so we can print and brand the workflow.
     wl_key: str = compute_wl_key(


### PR DESCRIPTION
## Summary
- centralize `--counts` string parsing in `phaseedge.cli.common.parse_counts_arg`
- reuse shared parser in `add_random_mace_relax`, `ensure_ce`, and `ensure_wang_landau`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b219957f648325bb061be968f57261